### PR TITLE
Step 3: Integrate H2 In-Memory Database and Migrate to JPA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,85 +1,99 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.0</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>com.taskmanager</groupId>
-	<artifactId>taskapp</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name>taskapp</name>
-	<description>	REST API for managing users, tasks, and notifications by LIKOLA MISHECK </description>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
-	<properties>
-		<java.version>17</java.version>
-	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-devtools</artifactId>
-			<scope>runtime</scope>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.0</version>
+        <relativePath/>
+    </parent>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<annotationProcessorPaths>
-						<path>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</path>
-					</annotationProcessorPaths>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<excludes>
-						<exclude>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</exclude>
-					</excludes>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+    <groupId>com.taskmanager</groupId>
+    <artifactId>taskapp</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>taskapp</name>
+    <description>REST API for managing users, tasks, and notifications by LIKOLA MISHECK</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <!-- Web -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Spring Data JPA -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <!-- H2 In-Memory Database -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Devtools -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Compiler Plugin for Lombok -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
+            <!-- Spring Boot Plugin -->
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/src/main/java/com/taskmanager/taskapp/model/Notification.java
+++ b/src/main/java/com/taskmanager/taskapp/model/Notification.java
@@ -1,18 +1,31 @@
 package com.taskmanager.taskapp.model;
 
+import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
+@Entity
+@Table(name = "notifications")
 public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false)
     private Long userId;
+
+    @Column(nullable = false)
     private String message;
+
     private boolean read;
+
+    @Column(nullable = false)
     private LocalDateTime createdAt;
 
-    public Notification() {}
+    public Notification() {
+    }
 
-    public Notification(Long id, Long userId, String message, LocalDateTime createdAt) {
-        this.id = id;
+    public Notification(Long userId, String message, LocalDateTime createdAt) {
         this.userId = userId;
         this.message = message;
         this.read = false;
@@ -20,18 +33,44 @@ public class Notification {
     }
 
     // Getters and Setters
-    public Long getId() { return id; }
-    public void setId(Long id) { this.id = id; }
 
-    public Long getUserId() { return userId; }
-    public void setUserId(Long userId) { this.userId = userId; }
+    public Long getId() {
+        return id;
+    }
 
-    public String getMessage() { return message; }
-    public void setMessage(String message) { this.message = message; }
+    public void setId(Long id) {
+        this.id = id;
+    }
 
-    public boolean isRead() { return read; }
-    public void setRead(boolean read) { this.read = read; }
+    public Long getUserId() {
+        return userId;
+    }
 
-    public LocalDateTime getCreatedAt() { return createdAt; }
-    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public boolean isRead() {
+        return read;
+    }
+
+    public void setRead(boolean read) {
+        this.read = read;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
 }

--- a/src/main/java/com/taskmanager/taskapp/model/Task.java
+++ b/src/main/java/com/taskmanager/taskapp/model/Task.java
@@ -1,20 +1,34 @@
 package com.taskmanager.taskapp.model;
 
+import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
+@Entity
+@Table(name = "tasks")
 public class Task {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false)
     private Long userId;
+
+    @Column(nullable = false)
     private String description;
+
+    @Column(nullable = false)
     private LocalDateTime createdAt;
+
+    @Column(nullable = false)
     private LocalDateTime targetDate;
+
     private boolean completed;
     private boolean deleted;
 
     public Task() {}
 
-    public Task(Long id, Long userId, String description, LocalDateTime createdAt, LocalDateTime targetDate) {
-        this.id = id;
+    public Task(Long userId, String description, LocalDateTime createdAt, LocalDateTime targetDate) {
         this.userId = userId;
         this.description = description;
         this.createdAt = createdAt;
@@ -24,6 +38,7 @@ public class Task {
     }
 
     // Getters and Setters
+
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
 

--- a/src/main/java/com/taskmanager/taskapp/model/User.java
+++ b/src/main/java/com/taskmanager/taskapp/model/User.java
@@ -1,8 +1,19 @@
 package com.taskmanager.taskapp.model;
 
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "users")
 public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false, unique = true)
     private String username;
+
+    @Column(nullable = false)
     private String password;
 
     // Constructors

--- a/src/main/java/com/taskmanager/taskapp/repository/NotificationRepository.java
+++ b/src/main/java/com/taskmanager/taskapp/repository/NotificationRepository.java
@@ -1,0 +1,11 @@
+package com.taskmanager.taskapp.repository;
+
+import com.taskmanager.taskapp.model.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findByUserId(Long userId);
+    List<Notification> findByUserIdAndReadFalse(Long userId);
+}

--- a/src/main/java/com/taskmanager/taskapp/repository/TaskRepository.java
+++ b/src/main/java/com/taskmanager/taskapp/repository/TaskRepository.java
@@ -1,0 +1,11 @@
+package com.taskmanager.taskapp.repository;
+
+import com.taskmanager.taskapp.model.Task;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TaskRepository extends JpaRepository<Task, Long> {
+    List<Task> findByUserIdAndDeletedFalse(Long userId);
+    List<Task> findByUserIdAndCompletedFalseAndDeletedFalse(Long userId);
+}

--- a/src/main/java/com/taskmanager/taskapp/repository/UserRepository.java
+++ b/src/main/java/com/taskmanager/taskapp/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.taskmanager.taskapp.repository;
+
+import com.taskmanager.taskapp.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/com/taskmanager/taskapp/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/taskmanager/taskapp/service/impl/NotificationServiceImpl.java
@@ -1,37 +1,33 @@
 package com.taskmanager.taskapp.service.impl;
 
 import com.taskmanager.taskapp.model.Notification;
+import com.taskmanager.taskapp.repository.NotificationRepository;
 import com.taskmanager.taskapp.service.NotificationService;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
+import java.util.List;
 
 @Service
 public class NotificationServiceImpl implements NotificationService {
 
-    private final Map<Long, Notification> notifications = new HashMap<>();
-    private final AtomicLong notificationIdGenerator = new AtomicLong();
+    private final NotificationRepository notificationRepository;
+
+    public NotificationServiceImpl(NotificationRepository notificationRepository) {
+        this.notificationRepository = notificationRepository;
+    }
 
     @Override
     public List<Notification> getAllUserNotifications(Long userId) {
-        return notifications.values().stream()
-                .filter(n -> n.getUserId().equals(userId))
-                .collect(Collectors.toList());
+        return notificationRepository.findByUserId(userId);
     }
 
     @Override
     public List<Notification> getUnreadNotifications(Long userId) {
-        return notifications.values().stream()
-                .filter(n -> n.getUserId().equals(userId) && !n.isRead())
-                .collect(Collectors.toList());
+        return notificationRepository.findByUserIdAndReadFalse(userId);
     }
 
     @Override
     public void addNotification(Notification notification) {
-        notification.setId(notificationIdGenerator.incrementAndGet());
-        notification.setCreatedAt(java.time.LocalDateTime.now());
-        notifications.put(notification.getId(), notification);
+        notificationRepository.save(notification);
     }
 }

--- a/src/main/java/com/taskmanager/taskapp/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/taskmanager/taskapp/service/impl/UserServiceImpl.java
@@ -1,29 +1,29 @@
 package com.taskmanager.taskapp.service.impl;
 
 import com.taskmanager.taskapp.model.User;
+import com.taskmanager.taskapp.repository.UserRepository;
 import com.taskmanager.taskapp.service.UserService;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.Optional;
 
 @Service
 public class UserServiceImpl implements UserService {
 
-    private final Map<String, User> users = new HashMap<>();
-    private final AtomicLong userIdGenerator = new AtomicLong();
+    private final UserRepository userRepository;
+
+    public UserServiceImpl(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
 
     @Override
     public User register(User user) {
-        user.setId(userIdGenerator.incrementAndGet());
-        users.put(user.getUsername(), user);
-        return user;
+        return userRepository.save(user);
     }
 
     @Override
     public User login(String username, String password) {
-        User user = users.get(username);
-        return (user != null && user.getPassword().equals(password)) ? user : null;
+        Optional<User> user = userRepository.findByUsername(username);
+        return user.filter(u -> u.getPassword().equals(password)).orElse(null);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,14 @@
-spring.application.name=taskapp
+# Enable H2 Console
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+
+# H2 Database URL
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# JPA Configuration
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true

--- a/src/test/java/com/taskmanager/taskapp/service/NotificationServiceTest.java
+++ b/src/test/java/com/taskmanager/taskapp/service/NotificationServiceTest.java
@@ -1,51 +1,81 @@
 package com.taskmanager.taskapp.service;
 
 import com.taskmanager.taskapp.model.Notification;
+import com.taskmanager.taskapp.repository.NotificationRepository;
 import com.taskmanager.taskapp.service.impl.NotificationServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 public class NotificationServiceTest {
 
+    private NotificationRepository notificationRepository;
     private NotificationService notificationService;
 
     @BeforeEach
     public void setup() {
-        notificationService = new NotificationServiceImpl();
+        notificationRepository = mock(NotificationRepository.class);
+        notificationService = new NotificationServiceImpl(notificationRepository);
     }
 
     @Test
     public void testAddNotification() {
-        Notification n = new Notification(null, 1L, "Test message", LocalDateTime.now());
+        Notification n = new Notification();
+        n.setUserId(1L);
+        n.setMessage("Test message");
+        n.setCreatedAt(LocalDateTime.now());
+
+        when(notificationRepository.save(n)).thenReturn(n);
         notificationService.addNotification(n);
 
-        List<Notification> all = notificationService.getAllUserNotifications(1L);
-        assertEquals(1, all.size());
-        assertEquals("Test message", all.get(0).getMessage());
+        verify(notificationRepository, times(1)).save(n);
     }
 
     @Test
     public void testGetUnreadNotifications() {
-        Notification read = new Notification(null, 1L, "Read one", LocalDateTime.now());
-        read.setRead(true);
+        Notification unread = new Notification();
+        unread.setUserId(1L);
+        unread.setMessage("Unread one");
+        unread.setCreatedAt(LocalDateTime.now());
+        unread.setRead(false);
 
-        Notification unread = new Notification(null, 1L, "Unread one", LocalDateTime.now());
+        when(notificationRepository.findByUserIdAndReadFalse(1L))
+                .thenReturn(Collections.singletonList(unread));
 
-        notificationService.addNotification(read);
-        notificationService.addNotification(unread);
+        List<Notification> result = notificationService.getUnreadNotifications(1L);
 
-        List<Notification> unreadList = notificationService.getUnreadNotifications(1L);
-        assertEquals(1, unreadList.size());
-        assertEquals("Unread one", unreadList.get(0).getMessage());
+        assertEquals(1, result.size());
+        assertEquals("Unread one", result.get(0).getMessage());
+    }
+
+    @Test
+    public void testGetAllUserNotifications() {
+        Notification note1 = new Notification();
+        note1.setUserId(1L);
+        note1.setMessage("Message 1");
+
+        Notification note2 = new Notification();
+        note2.setUserId(1L);
+        note2.setMessage("Message 2");
+
+        when(notificationRepository.findByUserId(1L)).thenReturn(Arrays.asList(note1, note2));
+
+        List<Notification> result = notificationService.getAllUserNotifications(1L);
+        assertEquals(2, result.size());
     }
 
     @Test
     public void testNoNotifications() {
+        when(notificationRepository.findByUserId(99L)).thenReturn(Collections.emptyList());
+
         List<Notification> all = notificationService.getAllUserNotifications(99L);
         assertTrue(all.isEmpty());
     }

--- a/src/test/java/com/taskmanager/taskapp/service/UserServiceTest.java
+++ b/src/test/java/com/taskmanager/taskapp/service/UserServiceTest.java
@@ -1,42 +1,67 @@
 package com.taskmanager.taskapp.service;
 
 import com.taskmanager.taskapp.model.User;
+import com.taskmanager.taskapp.repository.UserRepository;
 import com.taskmanager.taskapp.service.impl.UserServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 public class UserServiceTest {
 
+    private UserRepository userRepository;
     private UserService userService;
 
     @BeforeEach
     public void setup() {
-        userService = new UserServiceImpl();
+        userRepository = mock(UserRepository.class);
+        userService = new UserServiceImpl(userRepository);
     }
 
     @Test
     public void testRegisterUser() {
-        User user = new User(null, "alice", "pass123");
+        User user = new User();
+        user.setUsername("alice");
+        user.setPassword("pass123");
+
+        User savedUser = new User();
+        savedUser.setId(1L);
+        savedUser.setUsername("alice");
+        savedUser.setPassword("pass123");
+
+        when(userRepository.save(user)).thenReturn(savedUser);
+
         User registered = userService.register(user);
+
         assertNotNull(registered.getId());
         assertEquals("alice", registered.getUsername());
+        verify(userRepository).save(user);
     }
 
     @Test
     public void testLoginSuccess() {
-        User user = new User(null, "bob", "mypassword");
-        userService.register(user);
+        User user = new User();
+        user.setUsername("bob");
+        user.setPassword("mypassword");
+
+        when(userRepository.findByUsername("bob")).thenReturn(Optional.of(user));
 
         User loggedIn = userService.login("bob", "mypassword");
+
         assertNotNull(loggedIn);
         assertEquals("bob", loggedIn.getUsername());
     }
 
     @Test
     public void testLoginFailure() {
+        when(userRepository.findByUsername("unknown")).thenReturn(Optional.empty());
+
         User loggedIn = userService.login("unknown", "wrong");
         assertNull(loggedIn);
     }
 }
+


### PR DESCRIPTION
This pull request completes Step 3 of the coursework:
Replaced in-memory HashMap storage with H2 in-memory database.
Configured Spring Data JPA.
Annotated all model classes as JPA entities (@Entity, @Id, etc.).
 Created repositories for User, Task, and Notification.
Updated all service implementations to use Spring Data JPA repositories.

Verified using H2 Console at /h2-console. All entity tables (USERS, TASKS, NOTIFICATIONS) are correctly created and working.
