### PR TITLE
Step 4: Add Docker support and root health endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17-jdk-slim
+WORKDIR /app
+COPY target/taskapp-0.0.1-SNAPSHOT.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+
+services:
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:h2:mem:testdb
+      SPRING_DATASOURCE_USERNAME: sa
+      SPRING_DATASOURCE_PASSWORD:
+      SPRING_JPA_HIBERNATE_DDL_AUTO: update
+
+  db:
+    image: oscarfonts/h2
+    ports:
+      - "1521:1521"
+    environment:
+      H2_OPTIONS: "-tcp -tcpAllowOthers -ifNotExists"

--- a/src/main/java/com/taskmanager/taskapp/controller/HomeController.java
+++ b/src/main/java/com/taskmanager/taskapp/controller/HomeController.java
@@ -1,0 +1,12 @@
+package com.taskmanager.taskapp.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HomeController {
+    @GetMapping("/")
+    public String home() {
+        return "Task Manager API is running";
+    }
+}


### PR DESCRIPTION
Changes Introduced:
Dockerfile: Added configuration to containerize the Spring Boot application.

docker-compose.yml: Configured service composition for both the application and the H2 database.

HomeController: Added a simple REST endpoint at / to verify the application is running.

Features:
Run the entire app stack using a single docker-compose up command.

View app logs and container health from the console.

Access http://localhost:8080/ to confirm the backend is online.

H2 console is available at /h2-console (in-memory database).

How to Test:
Build and start containers:

bash
Copy
Edit
docker-compose up --build
Visit http://localhost:8080/ → You should see the message:
"Task Manager API is running!"

Optionally, access H2 at http://localhost:8080/h2-console

Note:
This sets the stage for future production containerization and deployment.

